### PR TITLE
Next.js: Fix regression in 3.12.0 where deploys fail with a message a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@layer0/core": "^3.12.0",
-    "@layer0/next": "^3.12.0",
+    "@layer0/next": "file:.yalc/@layer0/next",
     "@layer0/prefetch": "^3.12.0",
     "@layer0/react": "^3.12.0",
     "@layer0/rum": "^2.1.0",


### PR DESCRIPTION
…bout not being able to find the prerender-manifest.json.