### PR TITLE
Clear the confusion of where to include the env variables

### DIFF
--- a/guides/deploying.md
+++ b/guides/deploying.md
@@ -68,7 +68,7 @@ You should always store your deploy token using your CI environment's secrets ma
 
 Here is an example GitHub action that deploys your site to {{ PRODUCT_NAME }}:
 
-This action assumes that you have created environments called "staging" and "production" and you have created a deploy key for your site and added it as a secret in your repo called "layer0_deploy_token". Read more on [accessing environment variables (other than layer0_deploy_token)](https://docs.layer0.co/guides/environments#section_accessing_environment_variables_at_build_time) which might be essential for your app during the build time and for server side requests (including SSG/SSR).
+This action assumes that you have created environments called "staging" and "production" and you have created a deploy key for your site and added it as a secret in your repo called "layer0_deploy_token". Read more on [accessing environment variables](https://docs.layer0.co/guides/environments#section_accessing_environment_variables_at_build_time) which might be essential for your app during the build time and for server-side requests (including SSG/SSR).
 
 ```yml
 # Add this file to your project at .github/workflows/{{ PRODUCT_NAME_LOWER }}.yml

--- a/guides/deploying.md
+++ b/guides/deploying.md
@@ -68,7 +68,7 @@ You should always store your deploy token using your CI environment's secrets ma
 
 Here is an example GitHub action that deploys your site to {{ PRODUCT_NAME }}:
 
-This action assumes that you have created environments called "staging" and "production" and you have created a deploy key for your site and added it as a secret in your repo called "layer0_deploy_token". Read more on [accessing environment variables (other than layer0_deploy_token)](https://docs.layer0.co/guides/environments#section_accessing_environment_variables_at_build_time) which might be essential for your app during the build time.
+This action assumes that you have created environments called "staging" and "production" and you have created a deploy key for your site and added it as a secret in your repo called "layer0_deploy_token". Read more on [accessing environment variables (other than layer0_deploy_token)](https://docs.layer0.co/guides/environments#section_accessing_environment_variables_at_build_time) which might be essential for your app during the build time and for server side requests (including SSG/SSR).
 
 ```yml
 # Add this file to your project at .github/workflows/{{ PRODUCT_NAME_LOWER }}.yml

--- a/guides/deploying.md
+++ b/guides/deploying.md
@@ -68,7 +68,7 @@ You should always store your deploy token using your CI environment's secrets ma
 
 Here is an example GitHub action that deploys your site to {{ PRODUCT_NAME }}:
 
-This action assumes that you have created environments called "staging" and "production" and you have created a deploy key for your site and added it as a secret in your repo called "layer0_deploy_token".
+This action assumes that you have created environments called "staging" and "production" and you have created a deploy key for your site and added it as a secret in your repo called "layer0_deploy_token". Read more on [accessing environment variables (other than layer0_deploy_token)](https://docs.layer0.co/guides/environments#section_accessing_environment_variables_at_build_time) which might be essential for your app during the build time.
 
 ```yml
 # Add this file to your project at .github/workflows/{{ PRODUCT_NAME_LOWER }}.yml


### PR DESCRIPTION
While I was following the GitHub Actions for deploying on Layer0, I placed the env variables referenced in the workflow to GitHub Secrets. After this didn't work, I reached out to support and it seems like just layer0_deploy_token needs to be added for deploying via CI, but other environment variables need to be added on Layer0 as per the [doc](https://docs.layer0.co/guides/environments#section_accessing_environment_variables_at_build_time).

Creating this pull request to link the sections as this would save lot of time scanning through docs to locate the answer and clear the confusion as to where shall the env. variables be placed during build time and for server computations (like as done in SSG/SSR)