### PR TITLE
Update Next i18n guide to include includeFiles option in layer.config.js

### DIFF
--- a/guides/next.md
+++ b/guides/next.md
@@ -417,4 +417,14 @@ module.exports = with{{ PRODUCT_NAME }}(
 )
 ```
 
+Finally, you will need to update your `layer0.config.js` to (includeFiles)[/guides/layer0_config#section_includefiles] where the locale files are stored. Example using the default of `/public`:
+```js
+module.exports = {
+  connector: '@layer0/next',
+  includeFiles: {
+    "public": true,
+  }
+}
+```
+
 A working example app can be found [here](https://github.com/layer0-docs/layer0-next-i18n-example).


### PR DESCRIPTION
Guide was missing this piece and it is unclear that it is necessary without it (Files end up in s3 but not lambda) 