### PR TITLE
Add example proxying to serverless to connectors guide

### DIFF
--- a/guides/connectors.md
+++ b/guides/connectors.md
@@ -162,6 +162,27 @@ module.exports = {
 }
 ```
 
+## routing to serverless
+If your connector needs to be run on the serverless tier, you can use the `js` backend exposed by `@layer0/core` 
+
+Example using the `BACKENDS.js` backend:
+
+```js
+const { BACKENDS } = require('@layer0/core/constants');
+const router = new Router()
+
+... 
+
+router.get('/some/:path*', ({ proxy, cache }) => {
+  cache(CACHE_PAGES)
+  proxy(BACKENDS.js)
+})
+
+...
+
+export default router
+```
+
 ## Testing your connector locally before publishing it to NPM
 
 To test your connector locally without publishing it to NPM:

--- a/guides/connectors.md
+++ b/guides/connectors.md
@@ -162,27 +162,6 @@ module.exports = {
 }
 ```
 
-## routing to serverless
-If your connector needs to be run on the serverless tier, you can use the `js` backend exposed by `@layer0/core` 
-
-Example using the `BACKENDS.js` backend:
-
-```js
-const { BACKENDS } = require('@layer0/core/constants');
-const router = new Router()
-
-... 
-
-router.get('/some/:path*', ({ proxy, cache }) => {
-  cache(CACHE_PAGES)
-  proxy(BACKENDS.js)
-})
-
-...
-
-export default router
-```
-
 ## Testing your connector locally before publishing it to NPM
 
 To test your connector locally without publishing it to NPM:

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -227,6 +227,19 @@ router.get('/assets/:path*', ({ serveStatic, cache }) => {
 })
 ```
 
+## Routing to serverless
+
+If your request needs to be run on the serverless tier, you can use the `renderWithApp` handler to render your result using your application. Use this method to respond with an SSR or API result from your application.
+
+Example using the `renderWithApp` handler:
+
+```js
+router.get('/some/:path*', ({ renderWithApp, cache }) => {
+  cache(CACHE_PAGES)
+  renderWithApp()
+})
+```
+
 ### Falling back to server-side rendering
 
 If you render some but not all paths for a given route at build time, you can fall back to server side rendering using the `onNotFound` option. Add the `loadingPage`
@@ -403,7 +416,7 @@ router.get(
   },
   ({ setResponseHeader }) => {
     setResponseHeader('x-robots-tag', 'noindex')
-  }
+  },
 )
 ```
 


### PR DESCRIPTION
Connector docs / docs in general didn't have any obvious references to using BACKENDS.js (__js__) so ended up being kind of an unknown magic thing, I assume it's OK to add this 