### PR TITLE
Update guides.json

### DIFF
--- a/guides/guides.json
+++ b/guides/guides.json
@@ -88,11 +88,6 @@
         "href": "/guides/[...guide]"
       },
       {
-        "text": "GraphQL",
-        "as": "/guides/graphql",
-        "href": "/guides/[...guide]"
-      },
-      {
         "text": "Split Testing",
         "as": "/guides/split_testing",
         "href": "/guides/[...guide]"


### PR DESCRIPTION
Fixes: Clicking on GraphQL under get started section navbar, leads to cdn's section instead.