### PR TITLE
Simplify getting started guide

### DIFF
--- a/guides/webapp_cdn_getting_started.md
+++ b/guides/webapp_cdn_getting_started.md
@@ -29,7 +29,7 @@ If you do not have an account yet, visit [{{ PRODUCT_NAME }}]({{ APP_URL }}/sign
 ## Create a New Layer0 Project
 
 ```bash
-npm i -g {{ PACKAGE_NAME }}/cli // yarn global add {{ PACKAGE_NAME }}/cli
+npm i -g {{ PACKAGE_NAME }}/cli # yarn global add {{ PACKAGE_NAME }}/cli
 ```
 
 Create your project by running:

--- a/guides/webapp_cdn_getting_started.md
+++ b/guides/webapp_cdn_getting_started.md
@@ -6,7 +6,7 @@ Deploying your web application behind Layer0 is the fastest and easiest way to s
 
 - Create a new Layer0 project
 - Configure edge caching using EdgeJS
-- Deploy your site so that you can start seeing the performance benefits made possible by Layer0's global edge network.
+- Deploy your site
 
 If any point, you want a more [detailed guide](/guides/traditional_sites), we've got that too.
 
@@ -22,14 +22,14 @@ A full production deployment requires changing your site's DNS to allow requests
 
 ## Create an Account
 
-If you do not have an account yet, visit [{{ PRODUCT_NAME }}]({{ APP_URL }}/signup) to create one. Do not create a site in the UI at this point, we will be deploying from the command line.
+If you do not have an account yet, visit [{{ PRODUCT_NAME }}]({{ APP_URL }}/signup) to create one.
 
 {{ SYSTEM_REQUIREMENTS }}
 
 ## Create a New Layer0 Project
 
 ```bash
-npm i -g {{ PACKAGE_NAME }}/cli
+npm i -g {{ PACKAGE_NAME }}/cli // yarn global add {{ PACKAGE_NAME }}/cli
 ```
 
 Create your project by running:
@@ -42,13 +42,13 @@ npx @layer0/cli@latest init
 
 In the `src` folder, there are the following files:
 
-- `service-worker.ts`: prefetches content and stores in cache
-- `shoppingFlowRouteHandler.ts`: implements caching rules
-- `cache.ts`: contains values applied to caching rules in `shoppingFlowRouteHandler.ts`
-- `routes.ts`: routes to be cached and prefetched are defined, as well as what to pass through without modification and what to serve up as static content.
+- `service-worker.ts`: prefetches content and stores in cache,
+- `shoppingFlowRouteHandler.ts`: implements caching rules,
+- `cache.ts`: contains values applied to caching rules in `shoppingFlowRouteHandler.ts`,
+- `routes.ts`: routes to be cached and prefetched are defined, as well as what to pass through without modification and what to serve up as static content,
 - `browser.ts`: entry point for the `main.js` javascript bundle which is added to the window.
 
-## Configure Caching and Prefetching
+## Configure Caching
 
 We need to configure caching in our newly created project. The project contains some generic starter routes already, but these should be customized to fit your site. These routes should be added in the `routes.ts` file.
 
@@ -110,21 +110,18 @@ export const CACHE_PAGES = {
 }
 ```
 
-Refer to the guides on [Routing](routing) and [Caching](caching) for the full syntax to use in your `routes.js` file.
+Refer to the guides on [Routing](routing) and [Caching](caching) for the full syntax to use in your `routes.ts` file.
 
 Learn [advanced prefetching techniques](#section_advanced_prefetching_techniques) to achieve the best possible performance.
 
-## Deploy code to {{ PRODUCT_NAME }}
+## Deploy to {{ PRODUCT_NAME }}
 
-Now that you're satisfied with your site in local development, it's time to deploy it to {{ PRODUCT_NAME }} Cloud. Once your code is deployed to {{ PRODUCT_NAME }} Cloud, you can formally evaluate site performance and QA functionality.
-
-To deploy your site to {{ PRODUCT_NAME }}, you must first [sign up]({{ APP_URL }}/signup) for an account.
+Now that you're satisfied with your site in local development, it's time to deploy it to the {{ PRODUCT_NAME }} Cloud. Once deployed, you can formally evaluate site performance and QA functionality.
 
 Deploy your site with the following command:
 
 ```bash
-# Root of project
-{{ CLI_NAME }} deploy
+{{ CLI_NAME }} deploy # Root of project
 ```
 
 Once your project code is up and running, you can view its performance from within the [app.layer0.co]({{ APP_URL }}) cockpit. Using the tools available here, you can understand the caching behavior of the routes you have added. Continue adding routes and dialing in your config until you are ready to launch the site and code.

--- a/guides/webapp_cdn_getting_started.md
+++ b/guides/webapp_cdn_getting_started.md
@@ -43,8 +43,8 @@ npx @layer0/cli@latest init
 In the `src` folder, there are the following files:
 
 - `service-worker.ts`: prefetches content and stores in cache,
-- `shoppingFlowRouteHandler.ts`: implements caching rules,
-- `cache.ts`: contains values applied to caching rules in `shoppingFlowRouteHandler.ts`,
+- `route-handler.ts`: implements caching rules,
+- `cache.ts`: contains values applied to caching rules in `route-handler.ts`,
 - `routes.ts`: routes to be cached and prefetched are defined, as well as what to pass through without modification and what to serve up as static content,
 - `browser.ts`: entry point for the `main.js` javascript bundle which is added to the window.
 
@@ -59,7 +59,7 @@ At this point, the only item that should require changing is a path match. We su
 ```typescript
 // src/routes.ts
 import { Router } from '{{ PACKAGE_NAME }}/core/router'
-import shoppingFlowRouteHandler from './shoppingFlowRouteHandler'
+import shoppingFlowRouteHandler from './route-handler'
 
 export default new Router()
   .get('/', shoppingFlowRouteHandler)
@@ -72,7 +72,7 @@ export default new Router()
 The handler function passed into a route match will determine the behavior of the cache for the request. Abstracting this handler function, allows it to apply to multiple routes.
 
 ```typescript
-// src/shoppingFlowRouteHandler.ts
+// src/route-handler.ts
 import { CACHE_PAGES } from './cache'
 import { RouteHandler } from '{{ PACKAGE_NAME }}/core/router/Router'
 
@@ -97,7 +97,7 @@ const ONE_DAY = 24 * ONE_HOUR
 const ONE_YEAR = 365 * ONE_DAY
 
 /**
- * The default cache setting for pages in the shopping flow
+ * The default cache setting for pages in the route handler flow
  */
 export const CACHE_PAGES = {
   edge: {

--- a/guides/webapp_cdn_getting_started.md
+++ b/guides/webapp_cdn_getting_started.md
@@ -10,6 +10,12 @@ Deploying your web application behind Layer0 is the fastest and easiest way to s
 
 If any point, you want a more [detailed guide](/guides/traditional_sites), we've got that too.
 
+## Example
+
+[Try the WebApp CDN Example Site](https://github.com/layer0-docs/layer0-cdn-example?button)
+[View the Code](https://github.com/layer0-docs/layer0-cdn-example?button)
+[Deploy to Layer0](https://app.layer0.co/deploy?button&deploy&repo=https://github.com/layer0-docs/layer0-cdn-example)
+
 ## Network Diagram
 
 As shown below, {{ PRODUCT_NAME }} becomes the main CDN for your site:

--- a/guides/webapp_cdn_getting_started.md
+++ b/guides/webapp_cdn_getting_started.md
@@ -42,11 +42,11 @@ npx @layer0/cli@latest init
 
 In the `src` folder, there are the following files:
 
-- `service-worker.ts`: prefetches content and stores in cache,
-- `route-handler.ts`: implements caching rules,
-- `cache.ts`: contains values applied to caching rules in `route-handler.ts`,
-- `routes.ts`: routes to be cached and prefetched are defined, as well as what to pass through without modification and what to serve up as static content,
-- `browser.ts`: entry point for the `main.js` javascript bundle which is added to the window.
+- `service-worker.ts`: prefetches content and stores in cache
+- `route-handler.ts`: implements caching rules
+- `cache.ts`: contains values applied to caching rules in `route-handler.ts`
+- `routes.ts`: routes to be cached and prefetched are defined, as well as what to pass through without modification and what to serve up as static content
+- `browser.ts`: entry point for the `main.js` javascript bundle which is added to the window
 
 ## Configure Caching
 


### PR DESCRIPTION
1. Removed what's after deploy your site: "..." because that is repetitive to the introduction line,
2. Even if the user goes ahead with the UI, right after the first click, they've to deploy with the CLI anyways,
3. Added yarn command for installing Layer0 CLI,
4. The section `configure caching and prefetching` contained no instructions specific to prefetching, hence removed prefetching from the header,
5. Removed the sign up to deploy in the last section as that has been already covered in the 2nd header on the page itself