### PR TITLE
update angular directions

### DIFF
--- a/guides/angular.md
+++ b/guides/angular.md
@@ -36,8 +36,10 @@ You should now have a working starter app. Run `ng serve` to see the application
 To deploy your Angular application on {{ PRODUCT_NAME }} it needs to support server-side rendering (SSR). To add SSR support, run:
 
 ```bash
-ng add @nguniversal/express-engine
+ng add @nguniversal/express-engine --clientProject {{PROJECT_NAME}}
 ```
+
+(Note: the `{{PROJECT_NAME}}` value comes from the `package.json` file and should match the value of the `name` key.
 
 Read more about server-side rendering in Angular [here](https://angular.io/guide/universal).
 


### PR DESCRIPTION
The current directions for Angular specify that you should run `ng add @nguniversal/express-engine` but running that command by itself returns an error:

```
$ ng add @nguniversal/express-engine
Skipping installation: Package already installed
Schematic input does not validate against the Schema: {}
Errors:

  Data path "" should have required property 'clientProject'.
```

After some googling I found [this comment](https://github.com/angular/universal/issues/1118#issuecomment-457054924) that includes the `--clientProject` flag and indicates it is necessary.