### PR TITLE
fix link in 'disabled' section

### DIFF
--- a/guides/caching.md
+++ b/guides/caching.md
@@ -233,7 +233,7 @@ The response was cached or served from the cache (see `{{ HEADER_PREFIX }}-t`).
 
 ### disabled
 
-The response was not cached because the edge caching was explicitly [disabled](#section_not_caching_a_response).
+The response was not cached because the edge caching was explicitly (see [Preventing a Response from being Cached](#section_preventing_a_response_from_being_cached)).
 
 ### no-max-age
 

--- a/guides/caching.md
+++ b/guides/caching.md
@@ -233,7 +233,7 @@ The response was cached or served from the cache (see `{{ HEADER_PREFIX }}-t`).
 
 ### disabled
 
-The response was not cached because the edge caching was explicitly (see [Preventing a Response from being Cached](#section_preventing_a_response_from_being_cached)).
+The response was not cached because the edge caching was explicitly disabled (see [Preventing a Response from being Cached](#section_preventing_a_response_from_being_cached)).
 
 ### no-max-age
 


### PR DESCRIPTION
I fixed the link so it points to the `Preventing a Response from being Cached` section. That has the content originally pointed to by the link when the `disabled` section was added.