### PR TITLE
Update Layer0 link domain name

### DIFF
--- a/src/pages/guides/angular.md
+++ b/src/pages/guides/angular.md
@@ -7,7 +7,7 @@ This guide shows you how to deploy an [Angular](https://angular.io) application 
 ## Example {/*example*/}
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-angular-example-default.layer0.link/category/hats">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-angular-example-default.layer0-limelight.link/category/hats">
     Try the Angular SSR Example Site
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-angular-example">

--- a/src/pages/guides/devtools.md
+++ b/src/pages/guides/devtools.md
@@ -56,7 +56,7 @@ Then, if you haven't already, enable `{{ PACKAGE_NAME }}/prefetch` in your servi
 
 ## Enabling or Disabling the Devtools {/*enabling-or-disabling-the-devtools*/}
 
-By default, {{ PRODUCT_NAME }} Devtools is enabled when your app is served from `localhost`, `127.0.0.1` or any `*.layer0.link` domain.
+By default, {{ PRODUCT_NAME }} Devtools is enabled when your app is served from `localhost`, `127.0.0.1` or any `*.layer0-limelight.link` domain.
 
 To customize when {{ PRODUCT_NAME }} Devtools appear:
 

--- a/src/pages/guides/ember_fastboot.md
+++ b/src/pages/guides/ember_fastboot.md
@@ -7,7 +7,7 @@ This guide shows you how to deploy [Ember Fastboot](https://ember-fastboot.com/)
 ## Example {/*example*/}
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-ember-fastboot-example-default.layer0.link">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-ember-fastboot-example-default.layer0-limelight.link">
    Try the Fastboot Example Site
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-ember-fastboot-example">

--- a/src/pages/guides/frontity.md
+++ b/src/pages/guides/frontity.md
@@ -7,7 +7,7 @@ This guide shows you how to deploy [Frontity](https://frontity.org/) apps on {{ 
 ## Example {/*example*/}
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-frontity-example-default.layer0.link">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-frontity-example-default.layer0-limelight.link">
    Try the the Ember.js Example Site
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-frontity-example">

--- a/src/pages/guides/next_commerce.md
+++ b/src/pages/guides/next_commerce.md
@@ -9,7 +9,7 @@ This guide shows you how to deploy the [Next.js Commerce](https://github.com/ver
 Here is an example of the [Next.js Commerce](https://nextjs.org/commerce) template running on {{ PRODUCT_NAME }}. It uses all of the latest Next.js 10 features including image optimization, localization, and incremental static regeneration with stale-while-revalidate.
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-nextjs-commerce-default.layer0.link">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-nextjs-commerce-default.layer0-limelight.link">
     Try the Next.js Commerce Example Site
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-nextjs-commerce-example">

--- a/src/pages/guides/nuxt.md
+++ b/src/pages/guides/nuxt.md
@@ -9,7 +9,7 @@ This guide shows you how to deploy a Nuxt.js application on {{ PRODUCT_NAME }}. 
 This Nuxt.js example app uses server-side rendering and prefetching to provide lightening-fast transitions between pages.
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-nuxt-example-default.layer0.link/category/hats">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-nuxt-example-default.layer0-limelight.link/category/hats">
    Try the Nuxt.js SSR Example Site
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-nuxt-example">
@@ -314,7 +314,7 @@ You can configure Nuxt to generate a sitemap in SSR mode with the following conf
 
 ```js
 export default {
-  ... 
+  ...
 
   // Modules: https://go.nuxtjs.dev/config-modules
   modules: [

--- a/src/pages/guides/nx.md
+++ b/src/pages/guides/nx.md
@@ -21,7 +21,7 @@ Here we use [Next.js](https://nextjs.org/) for the example Nx project.
   <ButtonLink
     variant="fill"
     type="default"
-    href="https://layer0-docs-layer0-nx-example-default.layer0.link">
+    href="https://layer0-docs-layer0-nx-example-default.layer0-limelight.link">
     Try the Nx Example Site
   </ButtonLink>
   <ButtonLink
@@ -48,7 +48,7 @@ Here we use [Next.js](https://nextjs.org/) for the example Nx project.
 
 ## Start a Nx project from scratch
 
-The following steps take you through set-up of a new Nx workspace. The same process can be used to add Layer0 to your existing Nx repo. 
+The following steps take you through set-up of a new Nx workspace. The same process can be used to add Layer0 to your existing Nx repo.
 
 ### Generate the Nx workspace
 
@@ -66,11 +66,11 @@ To create the workspace, run
 npx create-nx-workspace --preset=next
 ```
 
-There will be a series of questions. When the one to choose the `Application name` comes, enter __`layer0-nx-next-app`__. The other answers can be of your choosing. 
+There will be a series of questions. When the one to choose the `Application name` comes, enter __`layer0-nx-next-app`__. The other answers can be of your choosing.
 
-### Add {{ PRODUCT_NAME }} to the application 
+### Add {{ PRODUCT_NAME }} to the application
 
-Because Nx wants dependencies installed at root level, we will `init` the project at root level to install the necesssary packages, but setup configurations to read into the next app we generated. The {{ PRODUCT_NAME }} next connector expects to be in the project repo, so we will create our own custom connector with the necesssary configurations. 
+Because Nx wants dependencies installed at root level, we will `init` the project at root level to install the necesssary packages, but setup configurations to read into the next app we generated. The {{ PRODUCT_NAME }} next connector expects to be in the project repo, so we will create our own custom connector with the necesssary configurations.
 
 ```bash
 0 init # installs necessary packages
@@ -89,7 +89,7 @@ Open `package.json` and change the `scripts > build` to the following:
 "build": "nx build layer0-nx-next-app",
 ```
 
-Open `layer0.config.js` and change the contents to the following: 
+Open `layer0.config.js` and change the contents to the following:
 
 ```js
 module.exports = {
@@ -98,7 +98,7 @@ module.exports = {
 };
 ```
 
-Open `routes.ts` and change to the following: 
+Open `routes.ts` and change to the following:
 
 ```js
 import { Router } from '@layer0/core/router';
@@ -111,7 +111,7 @@ export default new Router()
   .use(nextRoutes); // automatically adds routes for all files under /pages
 ```
 
-We need to add a custom connector now. You can either copy the whole folder from the example, or create each file below as instructed. 
+We need to add a custom connector now. You can either copy the whole folder from the example, or create each file below as instructed.
 
 ```
 mkdir layer0
@@ -168,7 +168,7 @@ module.exports = join('apps', 'layer0-nx-next-app');
 
 ### Development
 
-To start the app locally running with {{ PRODUCT_NAME }}, run 
+To start the app locally running with {{ PRODUCT_NAME }}, run
 
 ```bash
 0 dev
@@ -176,8 +176,8 @@ To start the app locally running with {{ PRODUCT_NAME }}, run
 
 ### Deploy
 
-To deploy the app to {{ PRODUCT_NAME }}, run 
+To deploy the app to {{ PRODUCT_NAME }}, run
 
 ```bash
-0 deploy 
+0 deploy
 ```

--- a/src/pages/guides/production.md
+++ b/src/pages/guides/production.md
@@ -125,7 +125,7 @@ Before going live, ensure that all {{ PRODUCT_NAME }} IP addresses are allowed i
 
 All data transmitted to and from your {{ PRODUCT_NAME }} site must be secured with TLS (Transport Layer Security). TLS, also known as SSL (Secure Sockets Layer), is a cryptographic protocol to communicate securely over the Internet. TLS provides end-to-end data encryption and data integrity for all web requests.
 
-{{ PRODUCT_NAME }} provides a wildcard TLS certificate that covers the auto-generated domains that it assigns to your site (e.g {team}-{site}-{branch}-{version}.layer0.link). You need to provide your own certificate for your site's custom domains.
+{{ PRODUCT_NAME }} provides a wildcard TLS certificate that covers the auto-generated domains that it assigns to your site (e.g {team}-{site}-{branch}-{version}.layer0-limelight.link). You need to provide your own certificate for your site's custom domains.
 
 __Note:__ If you already have an existing certificate, you can use it by skipping ahead to [Uploading your Certificate](#section_uploading_your_certificate). Many customers who have existing certificates still choose to obtain a new one when adopting {{ PRODUCT_NAME }} so as not to reuse the same private key with more than one vendor/system._
 

--- a/src/pages/guides/razzle.md
+++ b/src/pages/guides/razzle.md
@@ -7,7 +7,7 @@ This guide shows you how to deploy [Razzle](https://razzlejs.org/) apps on {{ PR
 ## Example {/*example*/}
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-razzle-example-default.layer0.link">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-razzle-example-default.layer0-limelight.link">
    Try Razzle Example Site
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-razzle-example">

--- a/src/pages/guides/react.md
+++ b/src/pages/guides/react.md
@@ -9,7 +9,7 @@ This guide shows you how to serve a [React](https://reactjs.org/) application on
 Here's an example React app running on Layer0:
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-static-react-example-default.layer0.link/">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-static-react-example-default.layer0-limelight.link/">
    Try React Example Site
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/static-react-example">
@@ -40,7 +40,7 @@ $ cd layer0-cra
 $ {{ CLI_NAME }} init
 # Pick the following options for questions
 # > Add Layer0 to the current app
-# Hostname of origin site > layer0-docs-layer0-examples-api-default.layer0.link
+# Hostname of origin site > layer0-docs-layer0-examples-api-default.layer0-limelight.link
 ```
 
 Follow the additional sections below regarding the Create React App setup to finish the project setup.

--- a/src/pages/guides/sapper.md
+++ b/src/pages/guides/sapper.md
@@ -11,7 +11,7 @@ This guide shows you how to deploy [Sapper](https://sapper.svelte.dev/) apps on 
 This Sapper example app uses server-side rendering and prefetching to provide lightening-fast transitions between pages.
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-sapper-example-default.layer0.link/category/hats">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-sapper-example-default.layer0-limelight.link/category/hats">
    Try the Sapper SSR Example Site
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-sapper-example">

--- a/src/pages/guides/spartacus.md
+++ b/src/pages/guides/spartacus.md
@@ -5,7 +5,7 @@ title: Spartacus for SAP Commerce Cloud (formerly SAP Hybris)
 This guide shows you how to deploy [Spartacus](https://sap.github.io/spartacus-docs) apps on {{ PRODUCT_NAME }}.
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-spartacus-example-default.layer0.link/">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-spartacus-example-default.layer0-limelight.link/">
     Try the Spartacus Example Site
     </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-spartacus-example">

--- a/src/pages/guides/static_sites.md
+++ b/src/pages/guides/static_sites.md
@@ -11,7 +11,7 @@ This guide shows you how to serve generic static sites on {{ PRODUCT_NAME }}.
 Here are a few examples of common static sites served by {{ PRODUCT_NAME }}.
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-static-backbonejs-example-default.layer0.link/">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-static-backbonejs-example-default.layer0-limelight.link/">
    Backbone.js Static Example
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/static-backbonejs-example?button">
@@ -23,7 +23,7 @@ Here are a few examples of common static sites served by {{ PRODUCT_NAME }}.
 </ButtonLinksGroup>
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-static-react-example-default.layer0.link/">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-static-react-example-default.layer0-limelight.link/">
    React Static Example
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/static-react-example">
@@ -35,7 +35,7 @@ Here are a few examples of common static sites served by {{ PRODUCT_NAME }}.
 </ButtonLinksGroup>
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-static-vuejs-example-default.layer0.link/">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-static-vuejs-example-default.layer0-limelight.link/">
    Vue.js Static Example
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/static-vuejs-example">

--- a/src/pages/guides/vsf.md
+++ b/src/pages/guides/vsf.md
@@ -11,7 +11,7 @@ For adding {{ PRODUCT_NAME }} to Vue Storefront 1 app follow this [guide](/guide
 Here's an example Vue Storefront 2 app running on Layer0:
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-vue-storefront-commercetools-example-default.layer0.link">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-vue-storefront-commercetools-example-default.layer0-limelight.link">
    Try the Vue Storefront Example
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-vue-storefront-commercetools-example?button">

--- a/src/pages/guides/vsf1.md
+++ b/src/pages/guides/vsf1.md
@@ -5,7 +5,7 @@ title: Vue Storefront 1
 ## Example Site {/*example-site*/}
 
 <ButtonLinksGroup>
-  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-vue-storefront-example-default.layer0.link">
+  <ButtonLink variant="fill" type="default" href="https://layer0-docs-layer0-vue-storefront-example-default.layer0-limelight.link">
    Try the VSF1 Example Site
   </ButtonLink>
   <ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/layer0-docs/layer0-vue-storefront-example">


### PR DESCRIPTION
Live links that point to `layer0.link` are no longer working. This fixes the links for a lot of our framework guides.