### PR TITLE
Fix referenced constants in Fastboot Guide

### DIFF
--- a/src/pages/guides/ember_fastboot.md
+++ b/src/pages/guides/ember_fastboot.md
@@ -55,7 +55,7 @@ import loadInitializers from 'ember-load-initializers'
 import config from './config/environment'
 
 // add this to import {{ PRODUCT_NAME }} service worker prefetching functionality
-import { install } from '{{ CLI_NAME }}/prefetch/window'
+import { install } from '{{ PACKAGE_NAME }}/prefetch/window'
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix
@@ -81,7 +81,7 @@ Ember fastboot apps should always have the following in {{ CONFIG_FILE }}:
 
 ```js filename="/{{ CONFIG_FILE }}"
 module.exports = {
-  connector: '{{ CLI_NAME }}/fastboot',
+  connector: '{{ PACKAGE_NAME }}/fastboot',
   includeNodeModules: true, // this ensures that package.json dependencies are uploaded to the cloud
 }
 ```


### PR DESCRIPTION
The current version uses `import { install } from '0/prefetch/window';` and ` connector: '0/fastboot',` which are incorrect. The docs were using `{{ CLI_NAME }}` for both of these when `{{ PACKAGE_NAME }}` should have been used instead. 

```
'0/prefetch/window' -> '@layer0/prefetch/window'
'0/fastboot' -> '@layer0/fastboot'
```